### PR TITLE
Fix typo describing default # of color stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install tailwind-easing-gradients
       colorMode: 'lrgb',
       type: 'linear',
       easing: 'ease', // default settings
-      colorStops: 10,
+      colorStops: 15,
       directions: {
         't': 'to top',
         'r': 'to right',


### PR DESCRIPTION
`colorStops: 10` in the code example v.s.

> ### colorStops: 15
> 
> is the default. A lower number creates a more "low poly" gradient with less code but a higher risk of banding.